### PR TITLE
added support for modded rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 3D Models/*.blend1
 todo.txt
 *.zip
+
+.idea/

--- a/Realistic_Electric_Trains_0.1.1/config.lua
+++ b/Realistic_Electric_Trains_0.1.1/config.lua
@@ -10,4 +10,14 @@ config = {
 	pole_flow_limit_val = 1200000,
 	loco_max_energy_transfer = "200kJ",
 	loco_max_energy_transfer_val = 200000,
+	supported_rails = {
+		["straight-rail"] = true,
+		["curved-rail"] = true,
+		["bi-straight-rail-wood"] = true,
+		["bi-curved-rail-wood"] = true,
+		["bi-straight-rail-wood-bridge"] = true,
+		["bi-curved-rail-wood-bridge"] = true,
+		["bi-straight-rail-power"] = true,
+		["bi-curved-rail-power"] = true,
+	}
 }

--- a/Realistic_Electric_Trains_0.1.1/config.lua
+++ b/Realistic_Electric_Trains_0.1.1/config.lua
@@ -12,12 +12,6 @@ config = {
 	loco_max_energy_transfer_val = 200000,
 	supported_rails = {
 		["straight-rail"] = true,
-		["curved-rail"] = true,
-		["bi-straight-rail-wood"] = true,
-		["bi-curved-rail-wood"] = true,
-		["bi-straight-rail-wood-bridge"] = true,
-		["bi-curved-rail-wood-bridge"] = true,
-		["bi-straight-rail-power"] = true,
-		["bi-curved-rail-power"] = true,
+		["curved-rail"] = true
 	}
 }

--- a/Realistic_Electric_Trains_0.1.1/control.lua
+++ b/Realistic_Electric_Trains_0.1.1/control.lua
@@ -142,7 +142,7 @@ script.on_event({
 		elseif n == "ret-electric-locomotive" then
 				register_locomotive(event)
 
-		elseif n == "straight-rail" or n == "curved-rail" then
+		elseif config.supported_rails[n] then
 				add_rail(event)
 		end
 	end
@@ -200,7 +200,7 @@ script.on_event({
 		elseif n == "ret-electric-locomotive" then
 				deregister_locomotive(event)
 
-		elseif n == "straight-rail" or n == "curved-rail" then
+		elseif config.supported_rails[n] then
 				remove_rail(event)
 		end
 	end
@@ -305,7 +305,7 @@ script.on_event(defines.events.on_player_selected_area,
 	function (e)
 		if e.item == "ret-pole-debugger" then
 			for _, entity in pairs(e.entities) do
-				if entity.name == "straight-rail" or entity.name == "curved-rail" then
+				if config.supported_rails[entity.name] then
 					local power_provider = global.power_for_rail[entity.unit_number]
 					local powered = power_provider and power_provider.valid
 					display_powered_state(entity, not powered)

--- a/Realistic_Electric_Trains_0.1.1/control.lua
+++ b/Realistic_Electric_Trains_0.1.1/control.lua
@@ -133,6 +133,7 @@ script.on_event({
 	},
 	function (event)
 		local n = event.created_entity.name
+		local t = event.created_entity.type
 
 		if n == "ret-pole-placer" or
 		   n == "ret-signal-pole-placer" or
@@ -142,7 +143,7 @@ script.on_event({
 		elseif n == "ret-electric-locomotive" then
 				register_locomotive(event)
 
-		elseif config.supported_rails[n] then
+		elseif config.supported_rails[t] then
 				add_rail(event)
 		end
 	end
@@ -190,6 +191,7 @@ script.on_event({
 	},
 	function (event)
 		local n = event.entity.name
+		local t = event.entity.type
 
 		if n == "ret-pole-base-straight" or
 		   n == "ret-pole-base-diagonal" or
@@ -200,7 +202,7 @@ script.on_event({
 		elseif n == "ret-electric-locomotive" then
 				deregister_locomotive(event)
 
-		elseif config.supported_rails[n] then
+		elseif config.supported_rails[t] then
 				remove_rail(event)
 		end
 	end
@@ -305,7 +307,7 @@ script.on_event(defines.events.on_player_selected_area,
 	function (e)
 		if e.item == "ret-pole-debugger" then
 			for _, entity in pairs(e.entities) do
-				if config.supported_rails[entity.name] then
+				if config.supported_rails[entity.type] then
 					local power_provider = global.power_for_rail[entity.unit_number]
 					local powered = power_provider and power_provider.valid
 					display_powered_state(entity, not powered)

--- a/Realistic_Electric_Trains_0.1.1/control.lua
+++ b/Realistic_Electric_Trains_0.1.1/control.lua
@@ -6,14 +6,14 @@ require("logic.overhead_line")
 
 -- initialization
 script.on_init(
-	function(e)
-		-- init lookup tables
-		global.wire_for_pole = {}   -- Pole ID -> Wire Entity
-		global.power_for_pole = {}  -- Pole ID -> Power Entity
-		global.graphic_for_pole = {}-- Pole ID -> Graphic Entity
-		global.power_for_rail = {}  -- Rail ID -> Power Entity
-		global.electric_locos = {}  -- Loco ID -> Loco Entity
-	end
+		function(e)
+			-- init lookup tables
+			global.wire_for_pole = {}   -- Pole ID -> Wire Entity
+			global.power_for_pole = {}  -- Pole ID -> Power Entity
+			global.graphic_for_pole = {}-- Pole ID -> Graphic Entity
+			global.power_for_rail = {}  -- Rail ID -> Power Entity
+			global.electric_locos = {}  -- Loco ID -> Loco Entity
+		end
 )
 
 -- settings cache
@@ -59,7 +59,7 @@ function create_pole(event)
 	}
 
 	local pole_name, pole_direction = fix_pole_build_name_and_dir(
-	                                    actual_pole[placer_name], direction)
+			actual_pole[placer_name], direction)
 
 	local pole = surface.create_entity {
 		name = pole_name,
@@ -109,8 +109,8 @@ function create_pole(event)
 
 	-- connect to the next poles
 	install_pole(pole, {
-			show_failures = enable_failure_text, 
-			show_particles = enable_connect_particles
+		show_failures = enable_failure_text,
+		show_particles = enable_connect_particles
 	})
 
 	if enable_rewire_neighbours then
@@ -128,25 +128,25 @@ function add_rail(event)
 end
 
 script.on_event({
-		defines.events.on_built_entity,
-		defines.events.on_robot_built_entity
-	},
-	function (event)
-		local n = event.created_entity.name
-		local t = event.created_entity.type
+	defines.events.on_built_entity,
+	defines.events.on_robot_built_entity
+},
+		function (event)
+			local n = event.created_entity.name
+			local t = event.created_entity.type
 
-		if n == "ret-pole-placer" or
-		   n == "ret-signal-pole-placer" or
-		   n == "ret-chain-pole-placer" then
+			if n == "ret-pole-placer" or
+					n == "ret-signal-pole-placer" or
+					n == "ret-chain-pole-placer" then
 				create_pole(event)
 
-		elseif n == "ret-electric-locomotive" then
+			elseif n == "ret-electric-locomotive" then
 				register_locomotive(event)
 
-		elseif config.supported_rails[t] then
+			elseif config.supported_rails[t] then
 				add_rail(event)
+			end
 		end
-	end
 )
 
 --==============================================================================
@@ -185,27 +185,27 @@ function remove_rail(event)
 end
 
 script.on_event({
-		defines.events.on_entity_died,
-		defines.events.on_pre_player_mined_item,
-		defines.events.on_robot_pre_mined
-	},
-	function (event)
-		local n = event.entity.name
-		local t = event.entity.type
+	defines.events.on_entity_died,
+	defines.events.on_pre_player_mined_item,
+	defines.events.on_robot_pre_mined
+},
+		function (event)
+			local n = event.entity.name
+			local t = event.entity.type
 
-		if n == "ret-pole-base-straight" or
-		   n == "ret-pole-base-diagonal" or
-		   n == "ret-signal-pole-base" or
-		   n == "ret-chain-pole-base" then
+			if n == "ret-pole-base-straight" or
+					n == "ret-pole-base-diagonal" or
+					n == "ret-signal-pole-base" or
+					n == "ret-chain-pole-base" then
 				destroy_pole(event)
 
-		elseif n == "ret-electric-locomotive" then
+			elseif n == "ret-electric-locomotive" then
 				deregister_locomotive(event)
 
-		elseif config.supported_rails[t] then
+			elseif config.supported_rails[t] then
 				remove_rail(event)
+			end
 		end
-	end
 )
 
 --==============================================================================
@@ -220,28 +220,26 @@ do
 
 	function on_tick(event)
 
-		if event.tick % 10 == 0 then
 
-			if not dummy_fuel then
-				dummy_fuel = game.item_prototypes["ret-dummy-fuel-1"]
-				dummy_fuel_value = dummy_fuel.fuel_value
-			end
+		if not dummy_fuel then
+			dummy_fuel = game.item_prototypes["ret-dummy-fuel-1"]
+			dummy_fuel_value = dummy_fuel.fuel_value
+		end
 
-			-- power all trains
-			for _, loco in pairs(global.electric_locos) do
-				local burner = loco.burner
-				burner.currently_burning = dummy_fuel
-				local missing_energy = dummy_fuel_value - burner.remaining_burning_fuel
-				local power_provider = find_power_provider(loco)
-				if power_provider then
-					local transfer = math.min(missing_energy, 
-									 math.min(power_provider.energy, max_transfer))
-					if transfer > 0 then
-						burner.remaining_burning_fuel =
-								burner.remaining_burning_fuel + transfer
-						power_provider.energy =
-								power_provider.energy - transfer
-					end
+		-- power all trains
+		for _, loco in pairs(global.electric_locos) do
+			local burner = loco.burner
+			burner.currently_burning = dummy_fuel
+			local missing_energy = dummy_fuel_value - burner.remaining_burning_fuel
+			local power_provider = find_power_provider(loco)
+			if power_provider then
+				local transfer = math.min(missing_energy,
+						math.min(power_provider.energy, max_transfer))
+				if transfer > 0 then
+					burner.remaining_burning_fuel =
+					burner.remaining_burning_fuel + transfer
+					power_provider.energy =
+					power_provider.energy - transfer
 				end
 			end
 		end
@@ -249,7 +247,7 @@ do
 
 end
 
-script.on_event(defines.events.on_tick, on_tick)
+script.on_nth_tick(10, on_tick)
 
 
 --==============================================================================
@@ -270,33 +268,33 @@ local pole_to_placer = {
 }
 
 script.on_event(defines.events.on_player_pipette,
-	function(e)
-		local replace = pole_to_placer[e.item.name]
-		if replace then
-			game.players[e.player_index].pipette_entity(replace)
+		function(e)
+			local replace = pole_to_placer[e.item.name]
+			if replace then
+				game.players[e.player_index].pipette_entity(replace)
+			end
 		end
-	end
 )
 
 script.on_event(defines.events.on_player_setup_blueprint,
-	function(e)
-		local stack = game.players[e.player_index].blueprint_to_setup
-		if stack.name == "blueprint" then
-			local entities = stack.get_blueprint_entities()
-			local modified = false
-			for _, entity in pairs(entities) do
-				if valid_poles[entity.name] then
-					local entity_name, entity_direction = fix_pole_name_and_dir(entity)
-					modified = true
-					entity.direction = entity_direction
-					entity.name = pole_to_placer[entity_name]
+		function(e)
+			local stack = game.players[e.player_index].blueprint_to_setup
+			if stack.name == "blueprint" then
+				local entities = stack.get_blueprint_entities()
+				local modified = false
+				for _, entity in pairs(entities) do
+					if valid_poles[entity.name] then
+						local entity_name, entity_direction = fix_pole_name_and_dir(entity)
+						modified = true
+						entity.direction = entity_direction
+						entity.name = pole_to_placer[entity_name]
+					end
+				end
+				if modified then
+					stack.set_blueprint_entities(entities)
 				end
 			end
-			if modified then
-				stack.set_blueprint_entities(entities)
-			end
 		end
-	end
 )
 
 --==============================================================================
@@ -304,30 +302,30 @@ script.on_event(defines.events.on_player_setup_blueprint,
 -- Selection script for the debugger
 
 script.on_event(defines.events.on_player_selected_area,
-	function (e)
-		if e.item == "ret-pole-debugger" then
-			for _, entity in pairs(e.entities) do
-				if config.supported_rails[entity.type] then
-					local power_provider = global.power_for_rail[entity.unit_number]
-					local powered = power_provider and power_provider.valid
-					display_powered_state(entity, not powered)
+		function (e)
+			if e.item == "ret-pole-debugger" then
+				for _, entity in pairs(e.entities) do
+					if config.supported_rails[entity.type] then
+						local power_provider = global.power_for_rail[entity.unit_number]
+						local powered = power_provider and power_provider.valid
+						display_powered_state(entity, not powered)
+					end
 				end
-			end 
+			end
 		end
-	end
 )
 
 --==============================================================================
 
 -- Commands
 
-commands.add_command("print_electric_train_count", 
-	"Prints how many electric trains are currently registered in the Realistic Electric Trains mod.",
-	function()
-		local count = 0
-		for _, _ in pairs(global.electric_locos) do
-			count = count + 1
+commands.add_command("print_electric_train_count",
+		"Prints how many electric trains are currently registered in the Realistic Electric Trains mod.",
+		function()
+			local count = 0
+			for _, _ in pairs(global.electric_locos) do
+				count = count + 1
+			end
+			game.print(string.format("Total Trains: %d", count))
 		end
-		game.print(string.format("Total Trains: %d", count))
-	end
 )

--- a/Realistic_Electric_Trains_0.1.1/logic/rail_search.lua
+++ b/Realistic_Electric_Trains_0.1.1/logic/rail_search.lua
@@ -298,7 +298,7 @@ function search_next_poles(start_pole, max_distance, ignore)
 		end
 	end
 	if ignore then
-		if config.supported_rails[ignore.name] then
+		if config.supported_rails[ignore.type] then
 			known_rails[ignore.unit_number] = true
 		else
 			known_poles[ignore.unit_number] = true

--- a/Realistic_Electric_Trains_0.1.1/logic/rail_search.lua
+++ b/Realistic_Electric_Trains_0.1.1/logic/rail_search.lua
@@ -14,7 +14,7 @@ function find_rails(pole)
 	local results = {}
 	for _, pos in pairs(positions) do
 		for _, entity in pairs(entities) do
-			if string.find(entity.name, pos.rail, 1, true) ~= nil and
+			if entity.type == pos.rail and
 			   entity.position.x == pos.x and
 			   entity.position.y == pos.y and
 			   entity.direction == pos.dir then
@@ -35,7 +35,7 @@ function find_adjacent_rails(rail, driving_direction)
 	local results = {}
 	for _, pos in pairs(positions) do
 		for _, entity in pairs(entities) do
-			if string.find(entity.name, pos.rail, 1, true) ~= nil and
+			if entity.type == pos.rail and
 			   entity.position.x == pos.x and
 			   entity.position.y == pos.y and
 			   entity.direction == pos.dir then
@@ -90,7 +90,7 @@ function check_curve_policy(start_position, find_result)
 	for k, rail in ipairs(path) do
 		if status == 0 then
 			-- first rail to be examined
-			if string.find(rail.name, "straight-rail", 1, true) then
+			if rail.type == "straight-rail" then
 				if rail.direction % 2 == 0 then
 					straight_count_before = straight_count_before + 1
 				else
@@ -111,7 +111,7 @@ function check_curve_policy(start_position, find_result)
 			end
 		elseif status == 1 then
 			-- waiting for first curve
-			if string.find(rail.name, "straight-rail", 1, true) then
+			if rail.type == "straight-rail" then
 				if rail.direction % 2 == 0 then
 					straight_count_before = straight_count_before + 1
 				else
@@ -129,7 +129,7 @@ function check_curve_policy(start_position, find_result)
 			end
 		elseif status == 2 then
 			-- after the first curve
-			if string.find(rail.name, "straight-rail", 1, true) then
+			if rail.type == "straight-rail" then
 				if rail.direction % 2 == 0 then
 					straight_count_after = straight_count_after + 1
 				else
@@ -208,7 +208,7 @@ function run_search_for_poles(start_position, check_list, known_poles, known_rai
 				for _, adjacent in pairs(rails) do
 					local rail = adjacent.rail
 					if not known_rails[rail.unit_number] then
-						local is_curve = string.find(rail.name, "curved-rail", 1, true) ~= nil
+						local is_curve = rail.type == "curved-rail"
 						local drive = adjacent.drive
 						local path = table.deepcopy(check.path)
 						table.insert(path, rail)
@@ -291,7 +291,7 @@ function search_next_poles(start_pole, max_distance, ignore)
 	local known_rails = {}
 	local known_poles = {[start_pole.unit_number] = true}
 	for _, rail in pairs(begin) do
-		local has_curve = string.find(rail.name,"curved-rail", 1, true) ~= nil
+		local has_curve = rail.type == "curved-rail"
 		known_rails[rail.unit_number] = true
 		for _, dir in pairs(driving_dirs_for_rail(rail.type, rail.direction)) do
 			table.insert(check_list, {rail = rail, drive = dir, path = {rail}, has_curve = has_curve})
@@ -316,7 +316,7 @@ function search_nearby_poles(start_rail, max_distance)
 	local known_rails = {[start_rail.unit_number] = true}
 	local known_poles = {}
 	for _, dir in pairs(driving_dirs_for_rail(start_rail.type, start_rail.direction)) do
-		local has_curve = string.find(start_rail.name,"curved-rail", 1, true) ~= nil
+		local has_curve = start_rail.type == "curved-rail"
 		table.insert(check_list, {rail = start_rail, drive = dir, path = {start_rail}, has_curve = has_curve})
 	end
 


### PR DESCRIPTION
Hi,

I added support for modded rails. In the config there is now a list of supported rail types. 
Wherever there was a check against the name there is now a check against the entity type.

This means all modded rails should work out of the box as they all share the `straight-rail` and `curved-rail` type.

Disclaimer: I only tested it on my machine in a heavily modded game with bioindustries powered rails.
Also I don't know your testing cycles.