### PR TITLE
Fix trains not getting the full power they need

### DIFF
--- a/Realistic_Electric_Trains_0.4.2/logic/events/on_tick.lua
+++ b/Realistic_Electric_Trains_0.4.2/logic/events/on_tick.lua
@@ -111,12 +111,11 @@ do
 
 
 	local enable_buffer = config.pole_enable_buffer
-	local update_factor = ticks_per_update / 60
 
 	function take_power(power_provider, missing_energy, max_transfer)
 		if power_provider.energy >= enable_buffer then
 			-- pole is powered, we can draw some power from it
-			local requested = math.min(missing_energy, max_transfer * update_factor)
+			local requested = math.min(missing_energy, max_transfer)
 
 			-- take stored power immediately
 			local power = math.min(requested, power_provider.energy - enable_buffer)
@@ -127,7 +126,7 @@ do
 			-- otherwise, reduce buffer size as much as possible
 			requested = requested - power
 			if requested > 0 then
-				local max_buffer = max_transfer * 2 * update_factor + enable_buffer
+				local max_buffer = max_transfer * 2 + enable_buffer
 				local buffer_increase = math.min(requested, max_buffer - power_provider.electric_buffer_size)
 				power = power + buffer_increase
 				power_provider.electric_buffer_size = power_provider.electric_buffer_size + buffer_increase


### PR DESCRIPTION
Seems like update_factor is no-longer needed, as values are now passed as per-tick values?