### PR TITLE
Add item names to locale

### DIFF
--- a/Realistic_Electric_Trains_0.4.4/locale/en/config.cfg
+++ b/Realistic_Electric_Trains_0.4.4/locale/en/config.cfg
@@ -25,6 +25,10 @@ ret-modular-locomotive=Modular Locomotive
 ret-pole-debugger=Overhead line debugger
 ret-pole-dummy-energy=Overhead line energy
 ret-pole-dummy-holder=Overhead line wire holder
+ret-train-speed-module=Locomotive Speed Module
+ret-train-efficiency-module=Locomotive Efficiency Module
+ret-train-productivity-module=Locomotive Productivity Module
+ret-train-battery-module=Locomotive Battery Module
 
 
 [equipment-name]


### PR DESCRIPTION
So the names display correctly in the craft window.